### PR TITLE
Improve Documentation & Compatibility Notes for V5.17.0+

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ You can find a list of available versions here: [Version History](https://www.te
 
 # Get Started - Patch / Enhance For v5.9.0 v5.10.0 and later (Maybe for all)
   > Note: For 5.17.0, `libfiddler.dll` is now renamed to `fiddler.dll`.
+  
+  > Note: So you need to get `Yukihana-Patch` release `1.1.0 +` for Fiddler Everywhere `5.17.0 +` 
 
 ## Windows
 

--- a/README.md
+++ b/README.md
@@ -22,22 +22,39 @@ api(dot)getfiddler(dot)com/mac/latest-mac
 
 api(dot)getfiddler(dot)com/mac-arm64/latest-mac
 
-# for v5.9.0 v5.10.0 and later (Maybe for all)
 
-## windows
+# How to Download Old Versiond of Fiddler Everywhere for *Windows*
 
-1. delete libfiddler.dll, rename `resources\app\out\WebServer\hostpolicy.dll` to `resources\app\out\WebServer\hostpolicy.original.dll`
-2. go to https://github.com/project-yukihana/Yukihana-patch/releases
-3. download `libfiddler` and `hostpolicy.dll`
-4. move `libfiddler.dll` to the root path of fiddler
-5. move `hostpolicy.dll` to `resources\app\out\WebServer`
-6. create file `resources\app\out\WebServer\patch.json`
+https://downloads.getfiddler.com/win/Fiddler%20Everywhere%20`(version)`.exe
+
+In the above link replace `(version)` with the versioon you want to download
+
+Ex: https://downloads.getfiddler.com/win/Fiddler%20Everywhere%205.17.0.exe to download `5.17.0`
+
+You can find a list of available versions here: [Version History](https://www.telerik.com/support/whats-new/fiddler-everywhere/release-history)
+
+
+# Get Started - Patch / Enhance For v5.9.0 v5.10.0 and later (Maybe for all)
+  > Note: For 5.17.0, `libfiddler.dll` is now renamed to `fiddler.dll`.
+
+## Windows
+
+### Special: Now you can Patch Fiddler Everywhere Automatically Too! - [Patch Automatically](https://github.com/sipsuru/fiddler-everywhere-patch-automated)
+
+### Patcch Manually: 
+
+1. Delete libfiddler.dll, (or fiddler.dll in 5.17.0+) & Rename `resources\app\out\WebServer\hostpolicy.dll` to `resources\app\out\WebServer\hostpolicy.original.dll`
+2. Go to https://github.com/project-yukihana/Yukihana-patch/releases
+3. Download `libfiddler` (or fiddler.dll in 5.17.0+) and `hostpolicy.dll`
+4. Move `libfiddler.dll` to the root path of fiddler
+5. Move `hostpolicy.dll` to `resources\app\out\WebServer`
+6. Create file `resources\app\out\WebServer\patch.json`
     
     the content of `patch.json`:
-    ```
+    ```json
     {
-        "ClientApp\\dist\\main.5f4387a481528ff0.js": {
-            "target": "ClientApp\\dist\\main.5f4387a481528ff0.original.js",
+        "ClientApp\\dist\\main.XXXXXXXXXX.js": {
+            "target": "ClientApp\\dist\\main.XXXXXXXXXX.original.js",
             "content": "",
             "cur": 0,
             "start": 0,
@@ -52,20 +69,26 @@ api(dot)getfiddler(dot)com/mac-arm64/latest-mac
         }
     }
     ```
-7. copy `ClientApp\\dist\\main.5f4387a481528ff0.js` to `ClientApp\\dist\\main.5f4387a481528ff0.original.js`
-8. copy `resources\app\out\main.js` to `resources\app\out\main.original.js`
-9. modify file `main.5f4387a481528ff0.js` and file `main.js` as usual.
-10. copy `server/file` -> `Fiddler/resources/app/out/file`
+
+    > Note: XXXXXXXXXX is a random letters combination that differs from version to version.
+
+    
+7. Copy `ClientApp\\dist\\main.XXXXXXXXXX.js` to `ClientApp\\dist\\main.XXXXXXXXXX.original.js`
+8. Copy `resources\app\out\main.js` to `resources\app\out\main.original.js`
+9. Modify file `main.XXXXXXXXXX.js` and file `main.js` as instructed bellow.
+10. Copy `server/file` -> `Fiddler/resources/app/out/file`
+
+> For windows, for more detailed info for noobs: [Windows Patch for Noobs](https://github.com/sipsuru/fiddler-everywhere-patch-manual)
 
 ## Linux
 
-1. delete `libfiddler.so`.
-2. go to https://github.com/project-yukihana/Yukihana-patch/releases
-3. download `libfiddler.so` and `libopen.so`
-4. move `libfiddler.so` to the root path of fiddler.
-5. move `libopen.so` to `resources/app/out/WebServer`
-6. rename `resources/app/out/WebServer/Fiddler.WebUi` to `resources/app/out/WebServer/Fiddler.WebUi1`
-7. create file `resources/app/out/WebServer/Fiddler.WebUi`
+1. Delete `libfiddler.so`.
+2. Go to https://github.com/project-yukihana/Yukihana-patch/releases
+3. Download `libfiddler.so` and `libopen.so`
+4. Move `libfiddler.so` to the root path of fiddler.
+5. Nove `libopen.so` to `resources/app/out/WebServer`
+6. Rename `resources/app/out/WebServer/Fiddler.WebUi` to `resources/app/out/WebServer/Fiddler.WebUi1`
+7. Create file `resources/app/out/WebServer/Fiddler.WebUi`
     
     the content of `Fiddler.WebUi`:
     ```shell
@@ -79,8 +102,8 @@ api(dot)getfiddler(dot)com/mac-arm64/latest-mac
     the content of `patch.json`:
     ```json
     {
-        "ClientApp/dist/main-XSH4ELY7.js": {
-            "target": "ClientApp/dist/main-XSH4ELY7.original.js",
+        "ClientApp/dist/main-XXXXXXXXXX.js": {
+            "target": "ClientApp/dist/main-XXXXXXXXXX.original.js",
             "content": "",
             "cur": 0,
             "start": 0,
@@ -95,22 +118,25 @@ api(dot)getfiddler(dot)com/mac-arm64/latest-mac
         }
     }
     ```
-10. copy `ClientApp/dist/main-XSH4ELY7.js` to `ClientApp/dist/main-XSH4ELY7.original.js`
-11. copy `resources/app/out/main.js` to `resources/app/out/main.original.js`
-12. modify file `main-XSH4ELY7.js` and file `main.js` as usual.
-13. copy `server/file` -> `Fiddler/resources/app/out/file`
+    > Note: XXXXXXXXXX is a random letters combination that differs from version to version.
 
-> You may need to recompile `libfiddler` and `libopen` by yourself.
+    
+10. Copy `ClientApp/dist/main-XXXXXXXXXX.js` to `ClientApp/dist/main-XXXXXXXXXX.original.js`
+11. Copy `resources/app/out/main.js` to `resources/app/out/main.original.js`
+12. Modify file `main-XXXXXXXXXX.js` and file `main.js` as instructed bellow.
+13. Copy `server/file` -> `Fiddler/resources/app/out/file`
+
+> You may need to recompile `libfiddler`(or fiddler.dll in 5.17.0+) and `libopen` by yourself.
 
 ## Mac 
 
-1. delete `libfiddler.dylib`. (`Contents/Frameworks`)
-2. go to https://github.com/project-yukihana/Yukihana-patch/releases
-3. download `libfiddler.dylib` and `libopen.dylib`
-4. move `libfiddler.dylib` to `Contents/Frameworks`.
-5. move `libopen.dylib` to `Resources/app/out/WebServer`
-6. rename `Resources/app/out/WebServer/Fiddler.WebUi` to `Resources/app/out/WebServer/Fiddler.WebUi1`
-7. create file `Resources/app/out/WebServer/Fiddler.WebUi`
+1. Delete `libfiddler.dylib`. (or fiddler.dll in 5.17.0+) which's in (`Contents/Frameworks`)
+2. Go to https://github.com/project-yukihana/Yukihana-patch/releases
+3. Download `libfiddler.dylib` (or fiddler.dll in 5.17.0+) and `libopen.dylib` 
+4. Move `libfiddler.dylib` to `Contents/Frameworks`.
+5. Move `libopen.dylib` to `Resources/app/out/WebServer`
+6. Rename `Resources/app/out/WebServer/Fiddler.WebUi` to `Resources/app/out/WebServer/Fiddler.WebUi1`
+7. Create file `Resources/app/out/WebServer/Fiddler.WebUi`
     
     the content of `Fiddler.WebUi`:
     ```shell
@@ -120,14 +146,14 @@ api(dot)getfiddler(dot)com/mac-arm64/latest-mac
     export DYLD_INSERT_LIBRARIES=./libopen.dylib
     ./Fiddler.WebUi1 $@
     ```
-8. open directory `Resources/app/out/WebServer` and execute `chmod +x Fiddler.WebUi`
-9. create file `Resources/app/out/WebServer/patch.json`
+8. Open directory `Resources/app/out/WebServer` and execute `chmod +x Fiddler.WebUi`
+9. Create file `Resources/app/out/WebServer/patch.json`
     
     the content of `patch.json`:
     ```json
     {
-        "ClientApp/dist/main-XSH4ELY7.js": {
-            "target": "ClientApp/dist/main-XSH4ELY7.original.js",
+        "ClientApp/dist/main-XXXXXXXXXX.js": {
+            "target": "ClientApp/dist/main-XXXXXXXXXX.original.js",
             "content": "",
             "cur": 0,
             "start": 0,
@@ -142,27 +168,27 @@ api(dot)getfiddler(dot)com/mac-arm64/latest-mac
         }
     }
     ```
-10. copy `ClientApp/dist/main-XSH4ELY7.js` to `ClientApp/dist/main-XSH4ELY7.original.js`
-11. copy `Resources/app/out/main.js` to `Resources/app/out/main.original.js`
-12. modify file `main-XSH4ELY7.js` and file `main.js` as usual.
-13. copy `server/file` -> `Contents/Resources/app/out/file`
+10. Copy `ClientApp/dist/main-XXXXXXXXX.js` to `ClientApp/dist/main-XSH4ELY7.original.js`
+11. Copy `Resources/app/out/main.js` to `Resources/app/out/main.original.js`
+12. Modify file `main-XXXXXXXXXX.js` and file `main.js` as instructed bellow.
+13. Copy `server/file` -> `Contents/Resources/app/out/file`
 
-> You may need to recompile `libfiddler` and `libopen` by yourself.
+> You may need to recompile `libfiddler` (or fiddler.dll in 5.17.0+) and `libopen` by yourself.
 
-# for xxx.js
+# How to Modity main.XXXXXXXXXX.js & main.js
 
-## 修改 main.js
+## For main.js
 
-1. 打开 `resources/app/out/main.js`
-2. `server/index.js` 的内容添加到 `resources/app/out/main.js` 开头
+1. Open `resources/app/out/main.js` in a text editor
+2. Open & copy content of `server/index.js` & append to `resources/app/out/main.js` at the begining.
 
-## 修改 main.xxx.js
+## For main.XXXXXXXXXX.js
 
-1. 打开 `resources/app/out/WebServer/ClientApp/dist/main.xxx.js`
-2. 替换所有 `https://api.getfiddler.com` 为 `http://127.0.0.1:5678/api.getfiddler.com`
-3. 替换所有 `https://identity.getfiddler.com` 为 `http://127.0.0.1:5678/identity.getfiddler.com`
+1. Open `resources/app/out/WebServer/ClientApp/dist/main.XXXXXXXXXX.js` in a text editor
+2. Find & Replace all - `https://api.getfiddler.com` with `http://127.0.0.1:5678/api.getfiddler.com`
+3. Find & Replace all - `https://identity.getfiddler.com` with `http://127.0.0.1:5678/identity.getfiddler.com`
 
-# Some Detail
+# Some Extra Details
 
 [Let me see old](./v4.6.2/readme.md)
 
@@ -170,14 +196,18 @@ api(dot)getfiddler(dot)com/mac-arm64/latest-mac
 
 ## 免责声明
 	
-本仓库仅供技术学习交流使用，如有下载相关文件，请在学习后24小时内删除相关内容。
+* 本仓库仅供技术学习交流使用，如有下载相关文件，请在学习后24小时内删除相关内容。
+* 如果你觉得软件很好用，请购买官方正版：https://www.telerik.com/purchase/fiddler
+* 切勿在 tb/pdd 等商城的非法渠道付费此软件。
+* 如将本仓库教程/文件用于获利，那么：你妈死了。
+* 请勿将本项目内容用于非法用途，使用者在使用时即视为对行为可能产生的任何不良后果负责。
+* 由于传播、利用此工具所提供的信息而造成的任何直接或者间接的后果及损失，均由使用者本人负责，作者不为此承担任何责任。
 
-如果你觉得软件很好用，请购买官方正版：https://www.telerik.com/purchase/fiddler
+## Disclaimer
 
-切勿在 tb/pdd 等商城的非法渠道付费此软件。
-
-如将本仓库教程/文件用于获利，那么：你妈死了。
-
-请勿将本项目内容用于非法用途，使用者在使用时即视为对行为可能产生的任何不良后果负责。
-	
-由于传播、利用此工具所提供的信息而造成的任何直接或者间接的后果及损失，均由使用者本人负责，作者不为此承担任何责任。
+* This repository is only for technical learning and communication. If you download related files, please delete the related content within 24 hours after learning.
+* If you think the software is useful, please buy the official version: https://www.telerik.com/purchase/fiddler
+* Do not pay for this software through illegal channels such as tb/pdd.
+* If you use this repository tutorial/file for profit, then: your mother is dead.
+* Please do not use the content of this project for illegal purposes. When using it, the user is deemed to be responsible for any adverse consequences that may arise from the behavior.
+* Any direct or indirect consequences and losses caused by the dissemination and use of the information provided by this tool are the responsibility of the user himself, and the author does not assume any responsibility for this.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ api(dot)getfiddler(dot)com/mac-arm64/latest-mac
 
 https://downloads.getfiddler.com/win/Fiddler%20Everywhere%20`(version)`.exe
 
-In the above link replace `(version)` with the versioon you want to download
+In the above link replace `(version)` with the version you want to download
 
 Ex: https://downloads.getfiddler.com/win/Fiddler%20Everywhere%205.17.0.exe to download `5.17.0`
 
@@ -43,7 +43,7 @@ You can find a list of available versions here: [Version History](https://www.te
 
 ### Special: Now you can Patch Fiddler Everywhere Automatically Too! - [Patch Automatically](https://github.com/sipsuru/fiddler-everywhere-patch-automated)
 
-### Patcch Manually: 
+### Patch Manually: 
 
 1. Delete libfiddler.dll, (or fiddler.dll in 5.17.0+) & Rename `resources\app\out\WebServer\hostpolicy.dll` to `resources\app\out\WebServer\hostpolicy.original.dll`
 2. Go to https://github.com/project-yukihana/Yukihana-patch/releases
@@ -77,7 +77,7 @@ You can find a list of available versions here: [Version History](https://www.te
     
 7. Copy `ClientApp\\dist\\main.XXXXXXXXXX.js` to `ClientApp\\dist\\main.XXXXXXXXXX.original.js`
 8. Copy `resources\app\out\main.js` to `resources\app\out\main.original.js`
-9. Modify file `main.XXXXXXXXXX.js` and file `main.js` as instructed bellow.
+9. Modify file `main.XXXXXXXXXX.js` and file `main.js` as instructed below.
 10. Copy `server/file` -> `Fiddler/resources/app/out/file`
 
 > For windows, for more detailed info for noobs: [Windows Patch for Noobs](https://github.com/sipsuru/fiddler-everywhere-patch-manual)
@@ -88,7 +88,7 @@ You can find a list of available versions here: [Version History](https://www.te
 2. Go to https://github.com/project-yukihana/Yukihana-patch/releases
 3. Download `libfiddler.so` and `libopen.so`
 4. Move `libfiddler.so` to the root path of fiddler.
-5. Nove `libopen.so` to `resources/app/out/WebServer`
+5. Move `libopen.so` to `resources/app/out/WebServer`
 6. Rename `resources/app/out/WebServer/Fiddler.WebUi` to `resources/app/out/WebServer/Fiddler.WebUi1`
 7. Create file `resources/app/out/WebServer/Fiddler.WebUi`
     
@@ -125,7 +125,7 @@ You can find a list of available versions here: [Version History](https://www.te
     
 10. Copy `ClientApp/dist/main-XXXXXXXXXX.js` to `ClientApp/dist/main-XXXXXXXXXX.original.js`
 11. Copy `resources/app/out/main.js` to `resources/app/out/main.original.js`
-12. Modify file `main-XXXXXXXXXX.js` and file `main.js` as instructed bellow.
+12. Modify file `main-XXXXXXXXXX.js` and file `main.js` as instructed below.
 13. Copy `server/file` -> `Fiddler/resources/app/out/file`
 
 > You may need to recompile `libfiddler`(or fiddler.dll in 5.17.0+) and `libopen` by yourself.
@@ -172,12 +172,12 @@ You can find a list of available versions here: [Version History](https://www.te
     ```
 10. Copy `ClientApp/dist/main-XXXXXXXXX.js` to `ClientApp/dist/main-XSH4ELY7.original.js`
 11. Copy `Resources/app/out/main.js` to `Resources/app/out/main.original.js`
-12. Modify file `main-XXXXXXXXXX.js` and file `main.js` as instructed bellow.
+12. Modify file `main-XXXXXXXXXX.js` and file `main.js` as instructed below.
 13. Copy `server/file` -> `Contents/Resources/app/out/file`
 
 > You may need to recompile `libfiddler` (or fiddler.dll in 5.17.0+) and `libopen` by yourself.
 
-# How to Modity main.XXXXXXXXXX.js & main.js
+# How to Modify main.XXXXXXXXXX.js & main.js
 
 ## For main.js
 


### PR DESCRIPTION
Updated libfiddler.dll -> fiddler.dll

Update some documentation that users couldn't understand easily.

Added links to download FE Old versions for Windows

Updated main.3244234412.js -> main.XXXXXXXX.js (Letters in new versions) in windows

Added links to automated patch repo for windows

Added links to manual patch repo for windows with extra details with visual instructing for noobs

Added Yukihana - Patch Compatibility Notice

Added English Translation for Disclaimer

Translated to English in main.XXXXXXXX.js and main.js Modify section. (Users often take wrong path and messes because they don't try to understand this - Actually by translating it)